### PR TITLE
Update mods2geoblacklight.xsl

### DIFF
--- a/lib/xslt/mods2geoblacklight.xsl
+++ b/lib/xslt/mods2geoblacklight.xsl
@@ -167,11 +167,11 @@
             <xsl:value-of select="text()"/>
           </field>
         </xsl:for-each>
-        <xsl:for-each select="mods:relatedItem/mods:titleInfo/mods:title">
+        <xsl:if test="mods:relatedItem[@type='host']">
           <field name="dct_isPartOf_sm">
-            <xsl:value-of select="text()"/>
+            <xsl:value-of select="mods:relatedItem/mods:titleInfo/mods:title"/>
           </field>
-        </xsl:for-each>
+        </xsl:if>
         <xsl:for-each select="mods:subject/mods:geographic">
           <field name="dct_spatial_sm">
             <xsl:value-of select="text()"/>


### PR DESCRIPTION
Mods has more than one type of relatedItem. the attribute 'host' is used to indicate Collection.
I added this attribute to the selection parameter.
Also changed xsl:for-each to xsl:if since there should only be 1 parent collection for each layer
