### PR TITLE
fixes #40. omit solr_bbox field

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -55,7 +55,7 @@
 
       -->
     <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
-    <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/>
+    <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- DEPRECATED -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
     <!-- <dynamicField name="*_jts"  type="location_jts" stored="true" indexed="true"/> -->
   </fields>

--- a/examples/generate-example-doc.rb
+++ b/examples/generate-example-doc.rb
@@ -28,7 +28,6 @@ layer = {
   :dc_format_s      => 'Shapefile',
   :layer_geom_type_s=> 'Polygon',
   :georss_box_s     => "#{s} #{w} #{n} #{e}", # SW NE in WGS84
-  :solr_bbox        => "#{w} #{s} #{e} #{n}", # minX minY maxX maxY
   :solr_geom        => "ENVELOPE(#{w}, #{e}, #{n}, #{s})"
 }
 

--- a/examples/selected.json
+++ b/examples/selected.json
@@ -20,7 +20,6 @@
     "layer_id_s": "sde:SDE_DATA.SF_WC_G46LEASEAREAS_1998",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:57:45Z",
-    "solr_bbox": "17.884351 -34.831394 23.373821 -30.970431",
     "solr_geom": "ENVELOPE(17.884351, 23.373821, -30.970431, -34.831394)",
     "solr_year_i": 1998
   },
@@ -45,7 +44,6 @@
     "layer_id_s": "sde:SDE_DATA.SZ_E29VAC_2002",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:58:07Z",
-    "solr_bbox": "30.794107 -27.325004 32.13726 -25.719648",
     "solr_geom": "ENVELOPE(30.794107, 32.13726, -25.719648, -27.325004)",
     "solr_year_i": 2002
   },
@@ -70,7 +68,6 @@
     "layer_id_s": "sde:SDE_DATA.US_F7MPO_2006",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:58:11Z",
-    "solr_bbox": "-178.339504 17.881241 -65.657677 64.920889",
     "solr_geom": "ENVELOPE(-178.339504, -65.657677, 64.920889, 17.881241)",
     "solr_year_i": 2006
   },
@@ -94,7 +91,6 @@
     "layer_id_s": "sde:SDE_DATA.US_MA_E25ZCTA5DCT_2000",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:58:31Z",
-    "solr_bbox": "-73.533237 41.230345 -69.898565 42.888068",
     "solr_geom": "ENVELOPE(-73.533237, -69.898565, 42.888068, 41.230345)",
     "solr_year_i": 2000
   },
@@ -119,7 +115,6 @@
     "layer_id_s": "sde:SDE_DATA.US_MA_CAMBRIDGE_C3BASINS_2007",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:58:58Z",
-    "solr_bbox": "-71.333763 42.34588 -71.23999 42.454013",
     "solr_geom": "ENVELOPE(-71.333763, -71.23999, 42.454013, 42.34588)",
     "solr_year_i": 2007
   },
@@ -147,7 +142,6 @@
     "layer_id_s": "sde:SDE_DATA.INT_A8MISPOP_2004",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T22:56:08Z",
-    "solr_bbox": "-179.989319 -54.94738 179.996979 81.823059",
     "solr_geom": "ENVELOPE(-179.989319, 179.996979, 81.823059, -54.94738)",
     "solr_year_i": 2004
   },
@@ -171,7 +165,6 @@
     "layer_id_s": "sde:SDE_DATA.NA_P61AIRPORTS_2009",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:24Z",
-    "solr_bbox": "-171.744183 18.003798 -52.723513 74.726026",
     "solr_geom": "ENVELOPE(-171.744183, -52.723513, 74.726026, 18.003798)",
     "solr_year_i": 2009
   },
@@ -199,7 +192,6 @@
     "layer_id_s": "sde:SDE_DATA.INT_A1CNTRY_2005",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:25Z",
-    "solr_bbox": "-180.0 -90.0 180.0 83.623599",
     "solr_geom": "ENVELOPE(-180.0, 180.0, 83.623599, -90.0)",
     "solr_year_i": 2005
   },
@@ -224,7 +216,6 @@
     "layer_id_s": "sde:SDE_DATA.US_MA_CAMBRIDGE_G46PORCH_2010",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:51Z",
-    "solr_bbox": "-71.163986 42.347255 -71.056155 42.405572",
     "solr_geom": "ENVELOPE(-71.163986, -71.056155, 42.405572, 42.347255)",
     "solr_year_i": 2010
   },
@@ -248,7 +239,6 @@
     "layer_id_s": "sde:SDE_DATA.EZ_F7DISTRICTS_2008",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:56Z",
-    "solr_bbox": "12.091061 48.551952 18.859166 51.055685",
     "solr_geom": "ENVELOPE(12.091061, 18.859166, 51.055685, 48.551952)",
     "solr_year_i": 2008
   },
@@ -273,7 +263,6 @@
     "layer_id_s": "sde:SDE_DATA.US_MA_CAMBRIDGE_S1CONSV_2007",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:56Z",
-    "solr_bbox": "-71.13405 42.366734 -71.099268 42.388156",
     "solr_geom": "ENVELOPE(-71.13405, -71.099268, 42.388156, 42.366734)",
     "solr_year_i": 2000
   },
@@ -298,7 +287,6 @@
     "layer_id_s": "sde:SDE_DATA.NA_N3NOREGESP_2008",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T22:56:57Z",
-    "solr_bbox": "-124.502718 25.83555 -66.980385 59.99968",
     "solr_geom": "ENVELOPE(-124.502718, -66.980385, 59.99968, 25.83555)",
     "solr_year_i": 2008
   },
@@ -323,7 +311,6 @@
     "layer_id_s": "sde:SDE_DATA.IN_HYDERABAD_P2ROAD_2007",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T22:57:17Z",
-    "solr_bbox": "78.31556 17.251062 78.626419 17.547419",
     "solr_geom": "ENVELOPE(78.31556, 78.626419, 17.547419, 17.251062)",
     "solr_year_i": 2007
   },
@@ -397,7 +384,6 @@
     "georss_box_s": "12.62309 76.760002 19.917049 84.719307",
     "georss_polygon_s": "12.62309 76.760002 19.917049 76.760002 19.917049 84.719307 12.62309 84.719307 12.62309 76.760002",
     "solr_geom": "ENVELOPE(76.760002, 84.719307, 19.917049, 12.62309)",
-    "solr_bbox": "76.760002 12.62309 84.719307 19.917049",
     "solr_year_i": 2009
   },
   {
@@ -461,7 +447,6 @@
     "georss_box_s": "16.31591 73.480431 22.672657 83.068985",
     "georss_polygon_s": "16.31591 73.480431 22.672657 73.480431 22.672657 83.068985 16.31591 83.068985 16.31591 73.480431",
     "solr_geom": "ENVELOPE(73.480431, 83.068985, 22.672657, 16.31591)",
-    "solr_bbox": "73.480431 16.31591 83.068985 22.672657",
     "solr_year_i": 2012
   },
   {
@@ -488,7 +473,6 @@
     "layer_id_s": "sde:SDE.TG00HIUNI",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:05:49Z",
-    "solr_bbox": "-178.339504 18.913826 -154.809286 28.4012960061664",
     "solr_geom": "ENVELOPE(-178.339504, -154.809286, 28.4012960061664, 18.913826)",
     "solr_year_i": 2000
   },
@@ -516,7 +500,6 @@
     "layer_id_s": "sde:SDE.TG00IDPLC",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:05:56Z",
-    "solr_bbox": "-117.059925 42.0108969985001 -111.098121998295 48.7352960016253",
     "solr_geom": "ENVELOPE(-117.059925, -111.098121998295, 48.7352960016253, 42.0108969985001)",
     "solr_year_i": 1990
   },
@@ -544,7 +527,6 @@
     "layer_id_s": "sde:SDE.TG00ILCTY00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:05:57Z",
-    "solr_bbox": "-91.511858 36.972675998666 -87.495829 42.508302",
     "solr_geom": "ENVELOPE(-91.511858, -87.495829, 42.508302, 36.972675998666)",
     "solr_year_i": 2000
   },
@@ -572,7 +554,6 @@
     "layer_id_s": "sde:SDE.TG00INLKA",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:06:02Z",
-    "solr_bbox": "-88.086901 37.773344 -84.788711 41.760688",
     "solr_geom": "ENVELOPE(-88.086901, -84.788711, 41.760688, 37.773344)",
     "solr_year_i": 2000
   },
@@ -600,7 +581,6 @@
     "layer_id_s": "sde:SDE.TG00MATRT",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:06:24Z",
-    "solr_bbox": "-73.508142 41.23796399957 -69.9278009999894 42.886789",
     "solr_geom": "ENVELOPE(-73.508142, -69.9278009999894, 42.886789, 41.23796399957)",
     "solr_year_i": 1990
   },
@@ -628,7 +608,6 @@
     "layer_id_s": "sde:SDE.TG00MILKD",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:06:33Z",
-    "solr_bbox": "-90.189096 41.7146549992204 -82.452009 47.175583000386",
     "solr_geom": "ENVELOPE(-90.189096, -82.452009, 47.175583000386, 41.7146549992204)",
     "solr_year_i": 2000
   },
@@ -656,7 +635,6 @@
     "layer_id_s": "sde:SDE.TG00MNUNI",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:06:38Z",
-    "solr_bbox": "-97.238567 43.4993559996548 -89.491638 49.3830790019576",
     "solr_geom": "ENVELOPE(-97.238567, -89.491638, 49.3830790019576, 43.4993559996548)",
     "solr_year_i": 2000
   },
@@ -684,7 +662,6 @@
     "layer_id_s": "sde:SDE.TG00MTLKF",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:06:50Z",
-    "solr_bbox": "-116.050003 44.3582089972235 -104.039563 49.0013900027765",
     "solr_geom": "ENVELOPE(-116.050003, -104.039563, 49.0013900027765, 44.3582089972235)",
     "solr_year_i": 2000
   },
@@ -712,7 +689,6 @@
     "layer_id_s": "sde:SDE.TG00MTPUMA",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:06:51Z",
-    "solr_bbox": "-116.050003 44.3582089972235 -104.039563 49.0013900027765",
     "solr_geom": "ENVELOPE(-116.050003, -104.039563, 49.0013900027765, 44.3582089972235)",
     "solr_year_i": 2000
   },
@@ -737,7 +713,6 @@
     "layer_id_s": "sde:SDE.TG00NJPUMA",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:07:09Z",
-    "solr_bbox": "-75.5597900005237 38.9285189995282 -73.9026749997039 41.3573710003341",
     "solr_geom": "ENVELOPE(-75.5597900005237, -73.9026749997039, 41.3573710003341, 38.9285189995282)",
     "solr_year_i": 2000
   },
@@ -765,7 +740,6 @@
     "layer_id_s": "sde:SDE.TG00ORLPT",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:07:26Z",
-    "solr_bbox": "-124.517278002017 42.002399 -116.663476999754 46.226335",
     "solr_geom": "ENVELOPE(-124.517278002017, -116.663476999754, 46.226335, 42.002399)",
     "solr_year_i": 2000
   },
@@ -790,7 +764,6 @@
     "layer_id_s": "sde:SDE.TG00PRPMS00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:07:33Z",
-    "solr_bbox": "-66.901384 18.011429 -65.527363 18.4947430005317",
     "solr_geom": "ENVELOPE(-66.901384, -65.527363, 18.4947430005317, 18.011429)",
     "solr_year_i": 2000
   },
@@ -818,7 +791,6 @@
     "layer_id_s": "sde:SDE.TG00VAAIR00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:07:59Z",
-    "solr_bbox": "-77.211952 37.32977499946 -76.912025 37.666327",
     "solr_geom": "ENVELOPE(-77.211952, -76.912025, 37.666327, 37.32977499946)",
     "solr_year_i": 2000
   },
@@ -846,7 +818,6 @@
     "layer_id_s": "sde:SDE.TG00VATRT00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:02Z",
-    "solr_bbox": "-83.675413 36.5407379982834 -75.2422659981058 39.4660120017166",
     "solr_geom": "ENVELOPE(-83.675413, -75.2422659981058, 39.4660120017166, 36.5407379982834)",
     "solr_year_i": 2000
   },
@@ -871,7 +842,6 @@
     "layer_id_s": "sde:SDE.TG00VILKD",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:08:04Z",
-    "solr_bbox": "-65.0330590000141 18.304013 -65.0016539999456 18.3681060000276",
     "solr_geom": "ENVELOPE(-65.0330590000141, -65.0016539999456, 18.3681060000276, 18.304013)",
     "solr_year_i": 2000
   },
@@ -899,7 +869,6 @@
     "layer_id_s": "sde:SDE.TG00VTSEC",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:08Z",
-    "solr_bbox": "-73.4304190002406 42.726853 -71.7658599998423 45.016659",
     "solr_geom": "ENVELOPE(-73.4304190002406, -71.7658599998423, 45.016659, 42.726853)",
     "solr_year_i": 2000
   },
@@ -924,7 +893,6 @@
     "layer_id_s": "sde:SDE.TG00WAPUMA",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:13Z",
-    "solr_bbox": "-124.76257800124 45.5483049977898 -116.917739 49.0024940000243",
     "solr_geom": "ENVELOPE(-124.76257800124, -116.917739, 49.0024940000243, 45.5483049977898)",
     "solr_year_i": 2000
   },
@@ -952,7 +920,6 @@
     "layer_id_s": "sde:SDE.TG95ALCDCPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:28Z",
-    "solr_bbox": "-88.473227 30.194045 -84.888967 35.007882",
     "solr_geom": "ENVELOPE(-88.473227, -84.888967, 35.007882, 30.194045)",
     "solr_year_i": 1995
   },
@@ -980,7 +947,6 @@
     "layer_id_s": "sde:SDE.TG95AZELMPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:33Z",
-    "solr_bbox": "-114.816591 31.332827 -109.336826 37.000532",
     "solr_geom": "ENVELOPE(-114.816591, -109.336826, 37.000532, 31.332827)",
     "solr_year_i": 1995
   },
@@ -1008,7 +974,6 @@
     "layer_id_s": "sde:SDE.TG95CACTYPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:36Z",
-    "solr_bbox": "-88.473227 30.194045 -84.888967 35.007882",
     "solr_geom": "ENVELOPE(-88.473227, -84.888967, 35.007882, 30.194045)",
     "solr_year_i": 1990
   },
@@ -1036,7 +1001,6 @@
     "layer_id_s": "sde:SDE.TG95COCCDPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:39Z",
-    "solr_bbox": "-109.060256 36.992426 -102.041485 41.003444",
     "solr_geom": "ENVELOPE(-109.060256, -102.041485, 41.003444, 36.992426)",
     "solr_year_i": 1990
   },
@@ -1064,7 +1028,6 @@
     "layer_id_s": "sde:SDE.TG95HISECPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:08:51Z",
-    "solr_bbox": "-160.249925 19.193584 -154.947649 22.238726",
     "solr_geom": "ENVELOPE(-160.249925, -154.947649, 22.238726, 19.193584)",
     "solr_year_i": 1995
   },
@@ -1089,7 +1052,6 @@
     "layer_id_s": "sde:SDE.KNG_POLICE",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:09:06Z",
-    "solr_bbox": "-122.471384 47.194663 -121.354454 47.775032",
     "solr_geom": "ENVELOPE(-122.471384, -121.354454, 47.775032, 47.194663)",
     "solr_year_i": 2002
   },
@@ -1116,7 +1078,6 @@
     "layer_id_s": "sde:SDE.MEACOMMSTAT95",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:09:17Z",
-    "solr_bbox": "-71.519051 42.080449 -70.62628 42.679402",
     "solr_geom": "ENVELOPE(-71.519051, -70.62628, 42.679402, 42.080449)",
     "solr_year_i": 1995
   },
@@ -1144,7 +1105,6 @@
     "layer_id_s": "sde:SDE.TG00ALCTY00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:09:38Z",
-    "solr_bbox": "-88.473227 30.194045 -84.8889669995051 35.007882",
     "solr_geom": "ENVELOPE(-88.473227, -84.8889669995051, 35.007882, 30.194045)",
     "solr_year_i": 2000
   },
@@ -1172,7 +1132,6 @@
     "layer_id_s": "sde:SDE.TG00ALKGL",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:09:39Z",
-    "solr_bbox": "-88.140385 31.038514 -85.214133 34.843686",
     "solr_geom": "ENVELOPE(-88.140385, -85.214133, 34.843686, 31.038514)",
     "solr_year_i": 2000
   },
@@ -1200,7 +1159,6 @@
     "layer_id_s": "sde:SDE.TG00CAAIR00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:09:51Z",
-    "solr_bbox": "-124.264319 32.6004359994021 -114.229314 41.9586080001738",
     "solr_geom": "ENVELOPE(-124.264319, -114.229314, 41.9586080001738, 32.6004359994021)",
     "solr_year_i": 2000
   },
@@ -1224,7 +1182,6 @@
     "layer_id_s": "cite:SDE.AMS7810_S250_U54_NG47_11",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:09:55Z",
-    "solr_bbox": "98.881922 24.774628 100.788377 26.090835",
     "solr_geom": "ENVELOPE(98.881922, 100.788377, 26.090835, 24.774628)",
     "solr_year_i": 2005
   },
@@ -1248,7 +1205,6 @@
     "layer_id_s": "cite:SDE.AMS7810_S250_U54_NG47_16",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:09:56Z",
-    "solr_bbox": "100.380246 23.758642 102.297172 25.116827",
     "solr_geom": "ENVELOPE(100.380246, 102.297172, 25.116827, 23.758642)",
     "solr_year_i": 2005
   },
@@ -1273,7 +1229,6 @@
     "layer_id_s": "sde:SDE.ARCBIKE",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:10:15Z",
-    "solr_bbox": "-84.9048 33.335655 -83.953468 34.250477",
     "solr_geom": "ENVELOPE(-84.9048, -83.953468, 34.250477, 33.335655)",
     "solr_year_i": 2002
   },
@@ -1298,7 +1253,6 @@
     "layer_id_s": "sde:SDE.ARCHHYDROLN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:10:18Z",
-    "solr_bbox": "72.0 -0.0 137.998199 53.562073",
     "solr_geom": "ENVELOPE(72.0, 137.998199, 53.562073, -0.0)",
     "solr_year_i": 1980
   },
@@ -1323,7 +1277,6 @@
     "layer_id_s": "sde:SDE.ARCMARTASTN",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:10:21Z",
-    "solr_bbox": "-84.470436 33.640682 -84.22966 33.943817",
     "solr_geom": "ENVELOPE(-84.470436, -84.22966, 33.943817, 33.640682)",
     "solr_year_i": 2000
   },
@@ -1347,7 +1300,6 @@
     "layer_id_s": "sde:SDE.BRLBOS",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:10:22Z",
-    "solr_bbox": "-71.176111 42.294585 -71.106357 42.351715",
     "solr_geom": "ENVELOPE(-71.176111, -71.106357, 42.351715, 42.294585)",
     "solr_year_i": 1990
   },
@@ -1375,7 +1327,6 @@
     "layer_id_s": "sde:SDE.ESRIEURCANALS",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:10:33Z",
-    "solr_bbox": "-8.2153 43.0226 34.8232 64.5189",
     "solr_geom": "ENVELOPE(-8.2153, 34.8232, 64.5189, 43.0226)",
     "solr_year_i": 1999
   },
@@ -1400,7 +1351,6 @@
     "layer_id_s": "sde:SDE.ESRIMIZIP",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:10:46Z",
-    "solr_bbox": "-90.418136 41.69609 -82.418635 48.190509",
     "solr_geom": "ENVELOPE(-90.418136, -82.418635, 48.190509, 41.69609)",
     "solr_year_i": 1999
   },
@@ -1428,7 +1378,6 @@
     "layer_id_s": "sde:SDE.TG95KSPLCPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:11:24Z",
-    "solr_bbox": "-102.042021 36.993634 -94.591033 40.000852",
     "solr_geom": "ENVELOPE(-102.042021, -94.591033, 40.000852, 36.993634)",
     "solr_year_i": 1990
   },
@@ -1456,7 +1405,6 @@
     "layer_id_s": "sde:SDE.TG95MILKBLN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:11:55Z",
-    "solr_bbox": "-90.219226 41.705252 -82.4206 47.249616",
     "solr_geom": "ENVELOPE(-90.219226, -82.4206, 47.249616, 41.705252)",
     "solr_year_i": 1995
   },
@@ -1484,7 +1432,6 @@
     "layer_id_s": "sde:SDE.TG95MTAIRCUPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:06Z",
-    "solr_bbox": "-114.84972 44.996355 -104.447006 48.998909",
     "solr_geom": "ENVELOPE(-114.84972, -104.447006, 48.998909, 44.996355)",
     "solr_year_i": 1995
   },
@@ -1512,7 +1459,6 @@
     "layer_id_s": "sde:SDE.TG95MTURBPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:08Z",
-    "solr_bbox": "-114.117709 45.732196 -108.377818 47.542742",
     "solr_geom": "ENVELOPE(-114.117709, -108.377818, 47.542742, 45.732196)",
     "solr_year_i": 1995
   },
@@ -1537,7 +1483,6 @@
     "layer_id_s": "sde:SDE.TG95NMTRTPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:24Z",
-    "solr_bbox": "-109.050173 31.332172 -103.001964 37.000293",
     "solr_geom": "ENVELOPE(-109.050173, -103.001964, 37.000293, 31.332172)",
     "solr_year_i": 1995
   },
@@ -1562,7 +1507,6 @@
     "layer_id_s": "sde:SDE.TG95NYCTYPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:29Z",
-    "solr_bbox": "-79.762152 40.496105 -71.85615 45.01258",
     "solr_geom": "ENVELOPE(-79.762152, -71.85615, 45.01258, 40.496105)",
     "solr_year_i": 1990
   },
@@ -1590,7 +1534,6 @@
     "layer_id_s": "sde:SDE.TG95OHLPTPT",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:12:33Z",
-    "solr_bbox": "-84.799501 38.600504 -80.520121 41.942469",
     "solr_geom": "ENVELOPE(-84.799501, -80.520121, 41.942469, 38.600504)",
     "solr_year_i": 1995
   },
@@ -1618,7 +1561,6 @@
     "layer_id_s": "sde:SDE.TG95ORTRTPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:40Z",
-    "solr_bbox": "-124.606788 41.991794 -116.463815 46.291029",
     "solr_geom": "ENVELOPE(-124.606788, -116.463815, 46.291029, 41.991794)",
     "solr_year_i": 1995
   },
@@ -1643,7 +1585,6 @@
     "layer_id_s": "sde:SDE.TG95SCCTYPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:12:48Z",
-    "solr_bbox": "-83.353019 32.047044 -78.541087 35.21554",
     "solr_geom": "ENVELOPE(-83.353019, -78.541087, 35.21554, 32.047044)",
     "solr_year_i": 1990
   },
@@ -1671,7 +1612,6 @@
     "layer_id_s": "sde:SDE.TG95VALKDLN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:13:05Z",
-    "solr_bbox": "-83.040174 36.544566 -75.391827 39.267754",
     "solr_geom": "ENVELOPE(-83.040174, -75.391827, 39.267754, 36.544566)",
     "solr_year_i": 1995
   },
@@ -1699,7 +1639,6 @@
     "layer_id_s": "sde:SDE.TG95VALKHLN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:13:06Z",
-    "solr_bbox": "-83.646854 36.540766 -75.166439 39.460297",
     "solr_geom": "ENVELOPE(-83.646854, -75.166439, 39.460297, 36.540766)",
     "solr_year_i": 1995
   },
@@ -1727,7 +1666,6 @@
     "layer_id_s": "sde:SDE.TG95VATAZPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:13:08Z",
-    "solr_bbox": "-80.262078 36.540738 -75.867044 39.466012",
     "solr_geom": "ENVELOPE(-80.262078, -75.867044, 39.466012, 36.540738)",
     "solr_year_i": 1995
   },
@@ -1752,7 +1690,6 @@
     "layer_id_s": "sde:SDE.TG95WVLKALN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:13:21Z",
-    "solr_bbox": "-82.641518 37.202467 -77.719193 40.62608",
     "solr_geom": "ENVELOPE(-82.641518, -77.719193, 40.62608, 37.202467)",
     "solr_year_i": 1995
   },
@@ -1776,7 +1713,6 @@
     "layer_id_s": "cite:SDE.USGS15MA_GREENFIE_1890",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:13:36Z",
-    "solr_bbox": "-72.803575 42.464463 -72.444311 42.782962",
     "solr_geom": "ENVELOPE(-72.803575, -72.444311, 42.782962, 42.464463)",
     "solr_year_i": 1886
   },
@@ -1800,7 +1736,6 @@
     "layer_id_s": "sde:SDE.VMAP1AQUEDCTL",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:13:40Z",
-    "solr_bbox": "-122.498123 -5.552861 140.668304 57.86618",
     "solr_geom": "ENVELOPE(-122.498123, 140.668304, 57.86618, -5.552861)",
     "solr_year_i": 1995
   },
@@ -1824,7 +1759,6 @@
     "layer_id_s": "sde:SDE.VMAP1EMBANKL",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:13:49Z",
-    "solr_bbox": "-122.498123 -5.552861 140.668304 57.86618",
     "solr_geom": "ENVELOPE(-122.498123, 140.668304, 57.86618, -5.552861)",
     "solr_year_i": 1995
   },
@@ -1848,7 +1782,6 @@
     "layer_id_s": "sde:SDE.VMAP1SEAICEA",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:13:58Z",
-    "solr_bbox": "-122.498123 -5.552861 140.668304 57.86618",
     "solr_geom": "ENVELOPE(-122.498123, 140.668304, 57.86618, -5.552861)",
     "solr_year_i": 1995
   },
@@ -1872,7 +1805,6 @@
     "layer_id_s": "sde:SDE.VMAP1VEGTXT",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:14:01Z",
-    "solr_bbox": "-122.498123 -5.552861 140.668304 57.86618",
     "solr_geom": "ENVELOPE(-122.498123, 140.668304, 57.86618, -5.552861)",
     "solr_year_i": 1995
   },
@@ -1897,7 +1829,6 @@
     "layer_id_s": "sde:SDE.TG00NMVOT00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:14:11Z",
-    "solr_bbox": "-109.050173 31.332172 -103.001964 37.000293",
     "solr_geom": "ENVELOPE(-109.050173, -103.001964, 37.000293, 31.332172)",
     "solr_year_i": 2000
   },
@@ -1925,7 +1856,6 @@
     "layer_id_s": "sde:SDE.TG95ILUNIPY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:14:18Z",
-    "solr_bbox": "-91.511858 36.972676 -87.495829 42.508302",
     "solr_geom": "ENVELOPE(-91.511858, -87.495829, 42.508302, 36.972676)",
     "solr_year_i": 1995
   },
@@ -1953,7 +1883,6 @@
     "layer_id_s": "sde:SDE2.ESRI07USBLKPOP_AK",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:14:26Z",
-    "solr_bbox": "-179.619163 51.261715 -130.02956 71.362955",
     "solr_geom": "ENVELOPE(-179.619163, -130.02956, 71.362955, 51.261715)",
     "solr_year_i": 2007
   },
@@ -1981,7 +1910,6 @@
     "layer_id_s": "sde:SDE2.ESRI07USBLKPOP_ME",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:14:28Z",
-    "solr_bbox": "-71.078845 42.988328 -66.953051 47.455327",
     "solr_geom": "ENVELOPE(-71.078845, -66.953051, 47.455327, 42.988328)",
     "solr_year_i": 2007
   },
@@ -2006,7 +1934,6 @@
     "layer_id_s": "sde:SDE2.ESRI12USTRACTS",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:14:54Z",
-    "solr_bbox": "-179.14734 17.881242 179.778465 71.390482",
     "solr_geom": "ENVELOPE(-179.14734, 179.778465, 71.390482, 17.881242)",
     "solr_year_i": 2011
   },
@@ -2034,7 +1961,6 @@
     "layer_id_s": "sde:SDE2.CH2000_L_F",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:15:19Z",
-    "solr_bbox": "73.44696 6.318641 135.085831 53.557926",
     "solr_geom": "ENVELOPE(73.44696, 135.085831, 53.557926, 6.318641)",
     "solr_year_i": 2000
   },
@@ -2059,7 +1985,6 @@
     "layer_id_s": "cite:SDE2.DMA50K_46751L",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:15:33Z",
-    "solr_bbox": "29.166189 -2.809968 29.578078 -2.48374",
     "solr_geom": "ENVELOPE(29.166189, 29.578078, -2.48374, -2.809968)",
     "solr_year_i": 1994
   },
@@ -2087,7 +2012,6 @@
     "layer_id_s": "sde:SDE2.ESRI04EURREGDEMOG",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:15:43Z",
-    "solr_bbox": "-31.2716 27.6374 66.096 71.1837",
     "solr_geom": "ENVELOPE(-31.2716, 66.096, 71.1837, 27.6374)",
     "solr_year_i": 2002
   },
@@ -2112,7 +2036,6 @@
     "layer_id_s": "sde:SDE2.ESRI04LAKES",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:15:45Z",
-    "solr_bbox": "-125.123318 -16.606264 109.965 67.046936",
     "solr_geom": "ENVELOPE(-125.123318, 109.965, 67.046936, -16.606264)",
     "solr_year_i": 1992
   },
@@ -2140,7 +2063,6 @@
     "layer_id_s": "sde:SDE2.ESRI04MXURBAN",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:15:47Z",
-    "solr_bbox": "-117.103118 14.868155 -86.740545 32.671682",
     "solr_geom": "ENVELOPE(-117.103118, -86.740545, 32.671682, 14.868155)",
     "solr_year_i": 2002
   },
@@ -2168,7 +2090,6 @@
     "layer_id_s": "sde:SDE2.EURATLAS_CITIES_1900",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:15:51Z",
-    "solr_bbox": "-17.0172 20.111204 50.882518 60.142962",
     "solr_geom": "ENVELOPE(-17.0172, 50.882518, 60.142962, 20.111204)",
     "solr_year_i": 1900
   },
@@ -2196,7 +2117,6 @@
     "layer_id_s": "sde:SDE.TG00COMSA00",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:16:26Z",
-    "solr_bbox": "-109.060253000045 37.7347039979905 -103.573306 41.002054",
     "solr_geom": "ENVELOPE(-109.060253000045, -103.573306, 41.002054, 37.7347039979905)",
     "solr_year_i": 2000
   },
@@ -2221,7 +2141,6 @@
     "layer_id_s": "cite:SDE2.G6714_N2_1826_J6",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:16:47Z",
-    "solr_bbox": "14.214461 40.821002 14.284335 40.870175",
     "solr_geom": "ENVELOPE(14.214461, 14.284335, 40.870175, 40.821002)",
     "solr_year_i": 1826
   },
@@ -2246,7 +2165,6 @@
     "layer_id_s": "cite:SDE2.G7064_S2_1834_K3",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:16:52Z",
-    "solr_bbox": "30.013108 59.669749 30.875309 60.041712",
     "solr_geom": "ENVELOPE(30.013108, 30.875309, 60.041712, 59.669749)",
     "solr_year_i": 1834
   },
@@ -2271,7 +2189,6 @@
     "layer_id_s": "cite:SDE2.G3774_P9_1849_C8",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:17:18Z",
-    "solr_bbox": "-71.467328 41.783244 -71.348564 41.866929",
     "solr_geom": "ENVELOPE(-71.467328, -71.348564, 41.866929, 41.783244)",
     "solr_year_i": 1849
   },
@@ -2296,7 +2213,6 @@
     "layer_id_s": "cite:SDE2.G3802_E44_1821_N4_SH2",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:17:21Z",
-    "solr_bbox": "-79.195411 42.449896 -76.310005 43.613922",
     "solr_geom": "ENVELOPE(-79.195411, -76.310005, 43.613922, 42.449896)",
     "solr_year_i": 1821
   },
@@ -2321,7 +2237,6 @@
     "layer_id_s": "cite:SDE2.G3804_N4_2M3_1845_S7_SH_2",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:17:25Z",
-    "solr_bbox": "-74.054649 40.707355 -73.868674 40.840761",
     "solr_geom": "ENVELOPE(-74.054649, -73.868674, 40.840761, 40.707355)",
     "solr_year_i": 1845
   },
@@ -2346,7 +2261,6 @@
     "layer_id_s": "cite:SDE2.G3804_N4C2_1961_G4_SH_6",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:17:25Z",
-    "solr_bbox": "-74.019901 40.463828 -73.72944 40.769208",
     "solr_geom": "ENVELOPE(-74.019901, -73.72944, 40.769208, 40.463828)",
     "solr_year_i": 1961
   },
@@ -2374,7 +2288,6 @@
     "layer_id_s": "sde:SDE2.AFRICOVER_TZ_SPAT_AGG",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:17:57Z",
-    "solr_bbox": "29.282125 -11.758909 40.448742 -0.91271",
     "solr_geom": "ENVELOPE(29.282125, 40.448742, -0.91271, -11.758909)",
     "solr_year_i": 2002
   },
@@ -2399,7 +2312,6 @@
     "layer_id_s": "cite:SDE2.AM_ONC_L04L",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:17:59Z",
-    "solr_bbox": "16.915415 -1.307164 30.171133 8.295335",
     "solr_geom": "ENVELOPE(16.915415, 30.171133, 8.295335, -1.307164)",
     "solr_year_i": 1988
   },
@@ -2424,7 +2336,6 @@
     "layer_id_s": "sde:SDE2.USGS_GT_GUATEMALA_CITY_HYP",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:18:05Z",
-    "solr_bbox": "-90.635468 14.516776 -90.455566 14.684624",
     "solr_geom": "ENVELOPE(-90.635468, -90.455566, 14.684624, 14.516776)",
     "solr_year_i": 2002
   },
@@ -2449,7 +2360,6 @@
     "layer_id_s": "sde:SDE2.USGS_NU_ESTELI_RDL",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:18:18Z",
-    "solr_bbox": "-86.420715 13.028337 -86.291663 13.154937",
     "solr_geom": "ENVELOPE(-86.420715, -86.291663, 13.154937, 13.028337)",
     "solr_year_i": 2001
   },
@@ -2474,7 +2384,6 @@
     "layer_id_s": "sde:SDE2.USGS_NU_LEON_RRL",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:18:23Z",
-    "solr_bbox": "-86.914301 12.400958 -86.815845 12.500048",
     "solr_geom": "ENVELOPE(-86.914301, -86.815845, 12.500048, 12.400958)",
     "solr_year_i": 2001
   },
@@ -2499,7 +2408,6 @@
     "layer_id_s": "sde:SDE2.USGS_NU_POSOLTEGA_DSL",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:18:28Z",
-    "solr_bbox": "-86.993251 12.512462 -86.971533 12.519664",
     "solr_geom": "ENVELOPE(-86.993251, -86.971533, 12.519664, 12.512462)",
     "solr_year_i": 2001
   },
@@ -2524,7 +2432,6 @@
     "layer_id_s": "cite:SDE2.VT3754_H52G46_1836_M3",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:18:35Z",
-    "solr_bbox": "-73.118302 44.971972 -73.093077 44.988599",
     "solr_geom": "ENVELOPE(-73.118302, -73.093077, 44.988599, 44.971972)",
     "solr_year_i": 1836
   },
@@ -2549,7 +2456,6 @@
     "layer_id_s": "cite:SDE2.MADRG_K42073B1",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:19:16Z",
-    "solr_bbox": "-73.261438 42.114387 -72.957086 42.260611",
     "solr_geom": "ENVELOPE(-73.261438, -72.957086, 42.260611, 42.114387)",
     "solr_year_i": 1987
   },
@@ -2574,7 +2480,6 @@
     "layer_id_s": "sde:SDE2.ESRI04USLALNDMRK",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:19:26Z",
-    "solr_bbox": "-176.810436 21.277891 -67.254855 68.83409",
     "solr_geom": "ENVELOPE(-176.810436, -67.254855, 68.83409, 21.277891)",
     "solr_year_i": 2002
   },
@@ -2602,7 +2507,6 @@
     "layer_id_s": "sde:SDE2.ESRI06EURPLACES",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:19:47Z",
-    "solr_bbox": "-27.2132 27.7652 64.0749 71.1666",
     "solr_geom": "ENVELOPE(-27.2132, 64.0749, 71.1666, 27.7652)",
     "solr_year_i": 2005
   },
@@ -2630,7 +2534,6 @@
     "layer_id_s": "sde:SDE2.ESRI06USBLKPOP_ME",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:19:51Z",
-    "solr_bbox": "-71.078845 42.988328 -66.953051 47.455327",
     "solr_geom": "ENVELOPE(-71.078845, -66.953051, 47.455327, 42.988328)",
     "solr_year_i": 2004
   },
@@ -2655,7 +2558,6 @@
     "layer_id_s": "cite:SDE2.MATWN_3764_B6P3_1850_P4",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:20:03Z",
-    "solr_bbox": "-71.102816 42.33403 -71.03331 42.399911",
     "solr_geom": "ENVELOPE(-71.102816, -71.03331, 42.399911, 42.33403)",
     "solr_year_i": 1850
   },
@@ -2680,7 +2582,6 @@
     "layer_id_s": "cite:SDE2.ME3732_P4_1798_C3",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:20:09Z",
-    "solr_bbox": "-68.977125 44.719836 -68.341555 45.309455",
     "solr_geom": "ENVELOPE(-68.977125, -68.341555, 45.309455, 44.719836)",
     "solr_year_i": 1798
   },
@@ -2708,7 +2609,6 @@
     "layer_id_s": "sde:SDE2.MGISBIOCHP",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:20:09Z",
-    "solr_bbox": "-73.532815 41.231147 -69.897279 42.873936",
     "solr_geom": "ENVELOPE(-73.532815, -69.897279, 42.873936, 41.231147)",
     "solr_year_i": 2001
   },
@@ -2732,7 +2632,6 @@
     "layer_id_s": "sde:SDE2.TG10NHVTD",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:20:34Z",
-    "solr_bbox": "-72.557185 42.696985 -70.575094 45.305476",
     "solr_geom": "ENVELOPE(-72.557185, -70.575094, 45.305476, 42.696985)",
     "solr_year_i": 2010
   },
@@ -2756,7 +2655,6 @@
     "layer_id_s": "sde:SDE2.TG10USAIANNH",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:20:35Z",
-    "solr_bbox": "-179.231086 17.831509 179.859681 71.441059",
     "solr_geom": "ENVELOPE(-179.231086, 179.859681, 71.441059, 17.831509)",
     "solr_year_i": 2010
   },
@@ -2781,7 +2679,6 @@
     "layer_id_s": "sde:SDE2.USGS_GT_CONCEPCION_MINAS_DNN",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:20:50Z",
-    "solr_bbox": "-89.50032 14.468522 -89.408323 14.558519",
     "solr_geom": "ENVELOPE(-89.50032, -89.408323, 14.558519, 14.468522)",
     "solr_year_i": 2002
   },
@@ -2806,7 +2703,6 @@
     "layer_id_s": "cite:SDE2.H008768589_V07_0007",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-12-15T23:22:06Z",
-    "solr_bbox": "-71.166945 42.348062 -71.152795 42.355179",
     "solr_geom": "ENVELOPE(-71.166945, -71.152795, 42.355179, 42.348062)",
     "solr_year_i": 1890
   },
@@ -2830,7 +2726,6 @@
     "layer_id_s": "massgis:GISDATA.ACECS_ARC",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:23:22Z",
-    "solr_bbox": "-73.51 41.533 -69.896 42.809",
     "solr_geom": "ENVELOPE(-73.51, -69.896, 42.809, 41.533)",
     "solr_year_i": 2009
   },
@@ -2854,7 +2749,6 @@
     "layer_id_s": "massgis:GISDATA.FISHTRAPS_PT",
     "layer_geom_type_s": "Point",
     "layer_modified_dt": "2014-12-15T23:23:18Z",
-    "solr_bbox": "-70.894 41.513 -69.967 42.693",
     "solr_geom": "ENVELOPE(-70.894, -69.967, 42.693, 41.513)",
     "solr_year_i": 1999
   },
@@ -2878,7 +2772,6 @@
     "layer_id_s": "massgis:GISDATA.REGDPHEPC_POLY",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:23:16Z",
-    "solr_bbox": "-73.533 41.231 -69.899 42.888",
     "solr_geom": "ENVELOPE(-73.533, -69.899, 42.888, 41.231)",
     "solr_year_i": 2005
   },
@@ -2903,7 +2796,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.JERUSALEMBUILDINGS08",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:28:29Z",
-    "solr_bbox": "34.796908 31.590286 35.399919 31.969706",
     "solr_geom": "ENVELOPE(34.796908, 35.399919, 31.969706, 31.590286)",
     "solr_year_i": 2008
   },
@@ -2928,7 +2820,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.TOGORIVERS97",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:24:56Z",
-    "solr_bbox": "0.224453 6.284239 1.806692 10.945619",
     "solr_geom": "ENVELOPE(0.224453, 1.806692, 10.945619, 6.284239)",
     "solr_year_i": 1997
   },
@@ -2953,7 +2844,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.DENMARK4DIGPOSTCODE06",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:25:26Z",
-    "solr_bbox": "8.072815 54.556986 15.197479 57.748161",
     "solr_geom": "ENVELOPE(8.072815, 15.197479, 57.748161, 54.556986)",
     "solr_year_i": 2006
   },
@@ -2978,7 +2868,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.IRELANDRIVERS06",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:25:27Z",
-    "solr_bbox": "-9.340549 51.832353 -6.229118 54.948913",
     "solr_geom": "ENVELOPE(-9.340549, -6.229118, 54.948913, 51.832353)",
     "solr_year_i": 2006
   },
@@ -3003,7 +2892,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.BULGARIAREGIONS06",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:25:35Z",
-    "solr_bbox": "22.357041 41.235367 28.607525 44.215463",
     "solr_geom": "ENVELOPE(22.357041, 28.607525, 44.215463, 41.235367)",
     "solr_year_i": 2006
   },
@@ -3028,7 +2916,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.BAHRAINROADS94",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:26:26Z",
-    "solr_bbox": "50.456937 25.997605 50.616835 26.251986",
     "solr_geom": "ENVELOPE(50.456937, 50.616835, 26.251986, 25.997605)",
     "solr_year_i": 1994
   },
@@ -3053,7 +2940,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.CHINAPROVINCES90",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:26:33Z",
-    "solr_bbox": "73.44696 6.318641 135.085831 53.557926",
     "solr_geom": "ENVELOPE(73.44696, 135.085831, 53.557926, 6.318641)",
     "solr_year_i": 1990
   },
@@ -3078,7 +2964,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.ISRAELPALESTINEGENEVABORD03",
     "layer_geom_type_s": "Line",
     "layer_modified_dt": "2014-12-15T23:26:46Z",
-    "solr_bbox": "34.204643 31.21777 35.554368 32.551948",
     "solr_geom": "ENVELOPE(34.204643, 35.554368, 32.551948, 31.21777)",
     "solr_year_i": 2008
   },
@@ -3103,7 +2988,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.EGYPTLAKES97",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:26:52Z",
-    "solr_bbox": "31.46795 22.191415 33.125147 30.416544",
     "solr_geom": "ENVELOPE(31.46795, 33.125147, 30.416544, 22.191415)",
     "solr_year_i": 1997
   },
@@ -3128,7 +3012,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.ALGERIALAKES97",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:01Z",
-    "solr_bbox": "-0.379543 33.909367 6.752684 35.562185",
     "solr_geom": "ENVELOPE(-0.379543, 6.752684, 35.562185, 33.909367)",
     "solr_year_i": 1997
   },
@@ -3153,7 +3036,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.ECUADOR1MLAKE08",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:05Z",
-    "solr_bbox": "-80.254573 -4.713863 -75.253186 0.734083",
     "solr_geom": "ENVELOPE(-80.254573, -75.253186, 0.734083, -4.713863)",
     "solr_year_i": 2011
   },
@@ -3178,7 +3060,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.MARLBOROUGHROADS09",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:06Z",
-    "solr_bbox": "-71.624997 42.313852 -71.479405 42.379861",
     "solr_geom": "ENVELOPE(-71.624997, -71.479405, 42.379861, 42.313852)",
     "solr_year_i": 2009
   },
@@ -3203,7 +3084,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.CAMBRIDGEPARKINGLOT03",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:19Z",
-    "solr_bbox": "-71.159325 42.352977 -71.064038 42.403102",
     "solr_geom": "ENVELOPE(-71.159325, -71.064038, 42.403102, 42.352977)",
     "solr_year_i": 2003
   },
@@ -3228,7 +3108,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.CAMBRIDGESTAIRS03",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:27Z",
-    "solr_bbox": "-71.161088 42.3531 -71.06682 42.404332",
     "solr_geom": "ENVELOPE(-71.161088, -71.06682, 42.404332, 42.3531)",
     "solr_year_i": 2003
   },
@@ -3253,7 +3132,6 @@
     "layer_id_s": "sde:GISPORTAL.GISOWNER01.CAMBRIDGETAXINGDISTFY11",
     "layer_geom_type_s": "Polygon",
     "layer_modified_dt": "2014-12-15T23:27:31Z",
-    "solr_bbox": "-71.160694 42.352677 -71.063809 42.403893",
     "solr_geom": "ENVELOPE(-71.160694, -71.063809, 42.403893, 42.352677)",
     "solr_year_i": 2011
   },
@@ -3291,7 +3169,6 @@
     "layer_id_s": "02870w62c",
     "layer_geom_type_s": "Raster",
     "layer_modified_dt": "2014-10-09T18:00:18Z",
-    "solr_bbox": "-76.3394 38.6693 -72.1916 46.5798",
     "solr_geom": "ENVELOPE(-76.3394, -72.1916, 46.5798, 38.6693)",
     "solr_year_i": 1778
   }

--- a/lib/xslt/fgdc2geoBL.xsl
+++ b/lib/xslt/fgdc2geoBL.xsl
@@ -538,29 +538,6 @@
           <xsl:value-of select="$x2"/>
         </field>
       
-     
-        <field name="solr_bbox">
-          <xsl:value-of select="$x1"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$y1"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$x2"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$y2"/>
-        </field>
-        
-        <field name="solr_sw_pt">
-          <xsl:value-of select="$y1"/>
-          <xsl:text>,</xsl:text>
-          <xsl:value-of select="$x1"/>
-        </field>
-        
-        <field name="solr_ne_pt">
-          <xsl:value-of select="$y2"/>
-          <xsl:text>,</xsl:text>
-          <xsl:value-of select="$x2"/>
-        </field>
-        
         <!-- content date: singular, or beginning date of range: YYYY -->
 
             <xsl:choose>

--- a/lib/xslt/iso2geoBL.xsl
+++ b/lib/xslt/iso2geoBL.xsl
@@ -495,7 +495,7 @@
         </field>
         
         <field name="solr_geom">
-          <xsl:text>ENVELOPE((</xsl:text>
+          <xsl:text>ENVELOPE(</xsl:text>
           <xsl:value-of select="$x1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$y1"/>
@@ -515,7 +515,7 @@
           <xsl:value-of select="$x1"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="$y1"/>
-          <xsl:text>))</xsl:text>
+          <xsl:text>)</xsl:text>
         </field>
         
         <field name="georss_box_s">
@@ -529,28 +529,6 @@
         </field>
       
      
-        <field name="solr_bbox">
-          <xsl:value-of select="$x1"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$y1"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$x2"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="$y2"/>
-        </field>
-        
-        <field name="solr_sw_pt">
-          <xsl:value-of select="$y1"/>
-          <xsl:text>,</xsl:text>
-          <xsl:value-of select="$x1"/>
-        </field>
-        
-        <field name="solr_ne_pt">
-          <xsl:value-of select="$y2"/>
-          <xsl:text>,</xsl:text>
-          <xsl:value-of select="$x2"/>
-        </field>
-        
         <!-- content date: singular, or beginning date of range: YYYY -->
          <xsl:choose>
            <xsl:when test="gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition/text() != ''">

--- a/lib/xslt/mods2geoblacklight.xsl
+++ b/lib/xslt/mods2geoblacklight.xsl
@@ -237,25 +237,6 @@
             <xsl:value-of select="$y1"/>
             <xsl:text>)</xsl:text>
           </field>
-          <field name="solr_bbox">
-            <xsl:value-of select="$x1"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$y1"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$x2"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="$y2"/>
-          </field>
-          <!-- <field name="solr_sw_pt">
-            <xsl:value-of select="$y1"/>
-            <xsl:text>,</xsl:text>
-            <xsl:value-of select="$x1"/>
-          </field>
-          <field name="solr_ne_pt">
-            <xsl:value-of select="$y2"/>
-            <xsl:text>,</xsl:text>
-            <xsl:value-of select="$x2"/>
-          </field> -->
         </xsl:for-each>
         <xsl:if test="mods:subject/mods:temporal[1]">
           <field name="solr_year_i">

--- a/tools/ogp/2_transform.rb
+++ b/tools/ogp/2_transform.rb
@@ -237,7 +237,7 @@ class TransformOgp
       :layer_modified_dt  => Time.now.utc.strftime('%FT%TZ'),
       
       # derived fields used only by solr, for which copyField is insufficient
-      :solr_bbox  => "#{w} #{s} #{e} #{n}", # minX minY maxX maxY
+      # :solr_bbox  => "#{w} #{s} #{e} #{n}", # minX minY maxX maxY
       # :solr_ne_pt => "#{n},#{e}",
       # :solr_sw_pt => "#{s},#{w}",
       :solr_geom  => "ENVELOPE(#{w}, #{e}, #{n}, #{s})",


### PR DESCRIPTION
fixes #40 

additionally fixes typo that created ENVELOPE((xxxx)) rather than ENVELOPE(xxxx)

also omits solr_sw_pt and solr_ne_pt which were deprecated long ago